### PR TITLE
fix shebang for venv

### DIFF
--- a/blend
+++ b/blend
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # Copyright (C) 2023 Rudra Saraswat
 #
 # This file is part of blend.

--- a/blend-files
+++ b/blend-files
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 import os
 import subprocess

--- a/blend-system
+++ b/blend-system
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # Copyright (C) 2023 Rudra Saraswat
 # 
 # This file is part of blend.


### PR DESCRIPTION
Trying to call any blend user, system, or associations while a python virtualenv is activated fail if the virtualenv doesn't have blend's dependencies installed in its site-packages. 

Switching the shebang to use /usr/bin/python3 fixes this because it no longer uses the venv python.