### PR TITLE
Added Ubuntu 24.04 LTS Container Support

### DIFF
--- a/blend
+++ b/blend
@@ -92,6 +92,7 @@ distro_map = {
     'fedora-39': 'registry.fedoraproject.org/fedora-toolbox:39',
     'centos': 'quay.io/toolbx-images/centos-toolbox:latest',
     'ubuntu-22.04': 'quay.io/toolbx/ubuntu-toolbox:22.04',
+    'ubuntu-24.04-lts': 'quay.io/toolbx/ubuntu-toolbox:24.04',
 }
 
 default_distro = 'arch-linux'

--- a/blend-settings/src/pages/containers.html
+++ b/blend-settings/src/pages/containers.html
@@ -15,6 +15,7 @@
             <option>CentOS</option>
             <option>Fedora 39</option>
             <option>Ubuntu 22.04</option>
+            <option>Ubuntu 24.04 LTS</option>
           </select>
         </div>
         <div class="col-sm-1">


### PR DESCRIPTION
I edited distro map in blend, and containers.html for adding Ubuntu 24.04 LTS container support, hoping to see it as an update!