### PR TITLE
Fix supported distro checking and handling

### DIFF
--- a/blend
+++ b/blend
@@ -103,7 +103,7 @@ def get_distro():
         return distro_map[args.distro]
     except:
         error(f"{args.distro} isn't supported by blend.")
-        exit()
+        exit(1)
 
 
 def list_containers():

--- a/user
+++ b/user
@@ -156,7 +156,7 @@ def associate_binary(association):
 
 @cli.command("create-container")
 @click.argument('container_name')
-@click.argument('distro', default='arch')
+@click.argument('distro', default='arch-linux')
 def create_container(container_name, distro):
     '''
     Create a container

--- a/user
+++ b/user
@@ -164,7 +164,11 @@ def create_container(container_name, distro):
     if subprocess.run(['podman', 'container', 'exists', container_name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0:
         error(f'container {colors.bold}{container_name}{colors.reset} already exists')
         exit(1)
-    exit(subprocess.run(['blend', 'create-container', '-cn', container_name, '-d', distro]).returncode)
+    args = ['blend', 'create-container', '-cn', container_name]
+    # blend handles no distro being specified already
+    if distro:
+        args.extend(['-d', distro])
+    exit(subprocess.run(args).returncode)
 
 @cli.command("delete-container")
 @click.argument('container')

--- a/user
+++ b/user
@@ -161,14 +161,10 @@ def create_container(container_name, distro):
     '''
     Create a container
     '''
-    if distro not in ('arch', 'almalinux-9', 'crystal-linux', 'debian', 'fedora-38', 'kali-linux', 'neurodebian-bookworm', 'rocky-linux', 'ubuntu-22.04', 'ubuntu-23.04'):
-        error(
-            f'distro {colors.bold}{distro}{colors.reset} not supported')
     if subprocess.run(['podman', 'container', 'exists', container_name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0:
         error(f'container {colors.bold}{container_name}{colors.reset} already exists')
         exit(1)
-    subprocess.run(['blend', 'create-container', '-cn', container_name, '-d', distro])
-
+    exit(subprocess.run(['blend', 'create-container', '-cn', container_name, '-d', distro]).returncode)
 
 @cli.command("delete-container")
 @click.argument('container')

--- a/user
+++ b/user
@@ -156,7 +156,7 @@ def associate_binary(association):
 
 @cli.command("create-container")
 @click.argument('container_name')
-@click.argument('distro', default='arch-linux')
+@click.argument('distro', required=False)
 def create_container(container_name, distro):
     '''
     Create a container


### PR DESCRIPTION
Previously, distros were checked in both `blend` and `user`, which led to `user`'s distro list being forgotten about and severely out of date, not to mention incorrect in the first place; it's a blessing that the code didn't work as it probably should have - that is, by exiting if the distro was unsupported.

With this, supported distro checking is handled by `blend` only, and it now has an exit code of 1 if the distro is unsupported, and user returns that exit code.