### PR TITLE
Fix dissociation not working and referencing old stuff

### DIFF
--- a/blend
+++ b/blend
@@ -19,7 +19,6 @@
 
 import os
 import sys
-import glob
 import time
 import shutil
 import socket
@@ -129,7 +128,7 @@ def check_container(name):
 
 
 def check_container_status(name):
-    if os.environ.get('SUDO_USER') == None:
+    if os.environ.get('SUDO_USER'):
         return host_get_output("podman inspect --type container " + name + " --format \"{{.State.Status}}\"")
     else:
         return host_get_output(f"sudo -u {os.environ.get('SUDO_USER')} podman inspect --type container " + name + " --format \"{{.State.Status}}\"")
@@ -137,7 +136,7 @@ def check_container_status(name):
 
 def core_start_container(name, new_container=False):
     sudo = []
-    if os.environ.get('SUDO_USER') != None:
+    if os.environ.get('SUDO_USER'):
         sudo = ['sudo', '-u', os.environ.get('SUDO_USER')]
     subprocess.call([*sudo, 'podman', 'start', name],
                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -150,7 +149,7 @@ def core_start_container(name, new_container=False):
         subprocess.call(['podman', 'logs', '--since', str(start_time), name])
         exit(1)
 
-    if os.environ.get('SUDO_USER') == None:
+    if not os.environ.get('SUDO_USER'):
         logproc = pexpect.spawn(
             'podman', args=['logs', '-f', '--since', str(start_time), name], timeout=3600)
     else:
@@ -393,7 +392,7 @@ def enter_container():
 
     podman_args = ['--env', 'LC_ALL=C.UTF-8']
     sudo = []
-    if os.environ.get('SUDO_USER') == None:
+    if not os.environ.get('SUDO_USER'):
         podman_args = ['--user', getpass.getuser()]
     else:
         sudo = ['sudo', '-u', os.environ.get(
@@ -402,7 +401,7 @@ def enter_container():
         if name not in ['LANG', 'LC_CTYPE', 'LC_ALL', 'PATH', 'HOST', 'HOSTNAME', 'SHELL'] and not name.startswith('_'):
             podman_args.append('--env')
             podman_args.append(name + '=' + val)
-    if os.environ.get('BLEND_COMMAND') == None or os.environ.get('BLEND_COMMAND') == '':
+    if not os.environ.get('BLEND_COMMAND'):
         if args.pkg == []:
             if os.getcwd() == os.path.expanduser('~') or os.getcwd().startswith(os.path.expanduser('~') + '/'):
                 exit(subprocess.call([*sudo, 'podman', 'exec', *podman_args,

--- a/blend
+++ b/blend
@@ -248,12 +248,12 @@ def core_run_container(cmd):
 
 
 def core_install_pkg(pkg):
-    if args.distro == 'fedora-rawhide':
+    if args.distro.startswith('fedora-'):
         if args.noconfirm == True:
             core_run_container(f'sudo dnf -y install {pkg}')
         else:
             core_run_container(f'sudo dnf install {pkg}')
-    elif args.distro == 'arch':
+    elif args.distro == 'arch-linux':
         if core_get_retcode('[ -f /usr/bin/yay ]') != 0:
             core_run_container('sudo pacman -Sy')
             core_run_container(
@@ -274,12 +274,12 @@ def core_install_pkg(pkg):
 
 
 def core_remove_pkg(pkg):
-    if args.distro == 'fedora-rawhide':
+    if args.distro.startswith('fedora-'):
         if args.noconfirm == True:
             core_run_container(f'sudo dnf -y remove {pkg}')
         else:
             core_run_container(f'sudo dnf remove {pkg}')
-    elif args.distro == 'arch':
+    elif args.distro == 'arch-linux':
         if args.noconfirm == True:
             core_run_container(f'sudo pacman --noconfirm -Rcns {pkg}')
         else:
@@ -293,9 +293,9 @@ def core_remove_pkg(pkg):
 
 
 def core_search_pkg(pkg):
-    if args.distro == 'fedora-rawhide':
+    if args.distro.startswith('fedora-'):
         core_run_container(f'dnf search {pkg}')
-    elif args.distro == 'arch':
+    elif args.distro == 'arch-linux':
         core_run_container(f'yay -Sy')
         core_run_container(f'yay {pkg}')
     elif args.distro.startswith('ubuntu-'):
@@ -304,9 +304,9 @@ def core_search_pkg(pkg):
 
 
 def core_show_pkg(pkg):
-    if args.distro == 'fedora-rawhide':
+    if args.distro.startswith('fedora-'):
         core_run_container(f'dnf info {pkg}')
-    elif args.distro == 'arch':
+    elif args.distro == 'arch-linux':
         core_run_container(f'yay -Sy')
         core_run_container(f'yay -Si {pkg}')
     elif args.distro.startswith('ubuntu-'):
@@ -358,21 +358,21 @@ def show_blend():
 
 
 def sync_blends():
-    if args.distro == 'fedora-rawhide':
+    if args.distro.startswith('fedora-'):
         core_run_container(f'dnf makecache')
-    elif args.distro == 'arch':
+    elif args.distro == 'arch-linux':
         core_run_container(f'yay -Syy')
     elif args.distro.startswith('ubuntu-'):
         core_run_container(f'sudo apt-get update')
 
 
 def update_blends():
-    if args.distro == 'fedora-rawhide':
+    if args.distro.startswith('fedora-'):
         if args.noconfirm == True:
             core_run_container(f'sudo dnf -y upgrade')
         else:
             core_run_container(f'sudo dnf upgrade')
-    elif args.distro == 'arch':
+    elif args.distro == 'arch-linux':
         if args.noconfirm == True:
             core_run_container(f'yay --noconfirm')
         else:

--- a/user
+++ b/user
@@ -138,7 +138,7 @@ def associate_binary(association, container):
 
 @cli.command("dissociate")
 @click.argument('association')
-def associate_binary(association):
+def dissociate_binary(association):
     '''
     Remove an association
     '''


### PR DESCRIPTION
This just fixes `associate_binary()`'s name being duplicated (presumably human error in not editing a copy-paste properly), and fixes blend referencing some old stuff, like `fedora-rawhide` and `arch` (not `arch-linux`)