### PR TITLE
Allow args for commands in containers

### DIFF
--- a/user
+++ b/user
@@ -1,12 +1,8 @@
 #!/usr/bin/python3
 
 import os
-import yaml
 import click
 import subprocess
-
-from urllib.request import urlopen
-
 
 class colors:
     reset = '\033[0m'

--- a/user
+++ b/user
@@ -208,6 +208,7 @@ def exec_c(container, cmds):
         exit(1)
     creation_env = os.environ.copy()
     creation_env['BLEND_NO_CHECK'] = 'true'
+    cmds = [ cmd.replace('\\-', '-') for cmd in cmds]
     subprocess.run(['blend', 'enter', '-cn', container, '--', *cmds], env=creation_env)
 
 


### PR DESCRIPTION
This allows args to be passed to commands running in containers by escaping the hyphens.

(and also removes some unused imports)