### PR TITLE
Fix distros/images not matching up, allow args 

### DIFF
--- a/blend
+++ b/blend
@@ -92,7 +92,7 @@ distro_map = {
     'fedora-39': 'registry.fedoraproject.org/fedora-toolbox:39',
     'centos': 'quay.io/toolbx-images/centos-toolbox:latest',
     'ubuntu-22.04': 'quay.io/toolbx/ubuntu-toolbox:22.04',
-    'ubuntu-24.04-lts': 'quay.io/toolbx/ubuntu-toolbox:24.04',
+    'ubuntu-24.04': 'quay.io/toolbx/ubuntu-toolbox:24.04',
 }
 
 default_distro = 'arch-linux'
@@ -168,8 +168,8 @@ def core_create_container():
     info(f'creating container {name}, using {distro}')
 
     if check_container(name):
-       error(f'container {name} already exists')
-       exit(1)
+        error(f'container {name} already exists')
+        exit(1)
 
     podman_command = []
 
@@ -248,12 +248,15 @@ def core_run_container(cmd):
 
 
 def core_install_pkg(pkg):
-    if args.distro == 'fedora-rawhide':
+    if args.distro == 'arch':
+        args.distro = 'arch-linux'
+
+    if args.distro.startswith('fedora-'):
         if args.noconfirm == True:
             core_run_container(f'sudo dnf -y install {pkg}')
         else:
             core_run_container(f'sudo dnf install {pkg}')
-    elif args.distro == 'arch':
+    elif args.distro == 'arch-linux':
         if core_get_retcode('[ -f /usr/bin/yay ]') != 0:
             core_run_container('sudo pacman -Sy')
             core_run_container(
@@ -274,12 +277,15 @@ def core_install_pkg(pkg):
 
 
 def core_remove_pkg(pkg):
-    if args.distro == 'fedora-rawhide':
+    if args.distro == 'arch':
+        args.distro = 'arch-linux'
+
+    if args.distro.startswith('fedora-'):
         if args.noconfirm == True:
             core_run_container(f'sudo dnf -y remove {pkg}')
         else:
             core_run_container(f'sudo dnf remove {pkg}')
-    elif args.distro == 'arch':
+    elif args.distro == 'arch-linux':
         if args.noconfirm == True:
             core_run_container(f'sudo pacman --noconfirm -Rcns {pkg}')
         else:
@@ -293,9 +299,12 @@ def core_remove_pkg(pkg):
 
 
 def core_search_pkg(pkg):
-    if args.distro == 'fedora-rawhide':
+    if args.distro == 'arch':
+        args.distro = 'arch-linux'
+
+    if args.distro.startswith('fedora-'):
         core_run_container(f'dnf search {pkg}')
-    elif args.distro == 'arch':
+    elif args.distro == 'arch-linux':
         core_run_container(f'yay -Sy')
         core_run_container(f'yay {pkg}')
     elif args.distro.startswith('ubuntu-'):
@@ -304,9 +313,12 @@ def core_search_pkg(pkg):
 
 
 def core_show_pkg(pkg):
-    if args.distro == 'fedora-rawhide':
+    if args.distro == 'arch':
+        args.distro = 'arch-linux'
+
+    if args.distro.startswith('fedora-'):
         core_run_container(f'dnf info {pkg}')
-    elif args.distro == 'arch':
+    elif args.distro == 'arch-linux':
         core_run_container(f'yay -Sy')
         core_run_container(f'yay -Si {pkg}')
     elif args.distro.startswith('ubuntu-'):
@@ -358,21 +370,27 @@ def show_blend():
 
 
 def sync_blends():
-    if args.distro == 'fedora-rawhide':
+    if args.distro == 'arch':
+        args.distro = 'arch-linux'
+
+    if args.distro.startswith('fedora-'):
         core_run_container(f'dnf makecache')
-    elif args.distro == 'arch':
+    elif args.distro == 'arch-linux':
         core_run_container(f'yay -Syy')
     elif args.distro.startswith('ubuntu-'):
         core_run_container(f'sudo apt-get update')
 
 
 def update_blends():
-    if args.distro == 'fedora-rawhide':
+    if args.distro == 'arch':
+        args.distro = 'arch-linux'
+
+    if args.distro.startswith('fedora-'):
         if args.noconfirm == True:
             core_run_container(f'sudo dnf -y upgrade')
         else:
             core_run_container(f'sudo dnf upgrade')
-    elif args.distro == 'arch':
+    elif args.distro == 'arch-linux':
         if args.noconfirm == True:
             core_run_container(f'yay --noconfirm')
         else:
@@ -428,6 +446,7 @@ def enter_container():
 
 def create_container():
     for container in args.pkg:
+        container = 'ubuntu-24.04' if container == 'ubuntu-24.04-lts' else container
         args.container_name = container
         if container in distro_map.keys() and distro_input == None:
             args.distro = container
@@ -443,10 +462,12 @@ def remove_container():
                        stdout=subprocess.DEVNULL)
         for bin in os.listdir(os.path.expanduser('~/.local/bin/blend_bin')):
             if bin.endswith(f'.{container}'):
-                os.remove(os.path.join(os.path.expanduser('~/.local/bin/blend_bin'), bin))
+                os.remove(os.path.join(os.path.expanduser(
+                    '~/.local/bin/blend_bin'), bin))
         for app in os.listdir(os.path.expanduser('~/.local/share/applications')):
             if app.startswith(f'blend;{container};'):
-                os.remove(os.path.join(os.path.expanduser('~/.local/share/applications'), app))
+                os.remove(os.path.join(os.path.expanduser(
+                    '~/.local/share/applications'), app))
 
 
 def start_containers():

--- a/blend
+++ b/blend
@@ -129,7 +129,7 @@ def check_container(name):
 
 
 def check_container_status(name):
-    if os.environ.get('SUDO_USER') == None:
+    if os.environ.get('SUDO_USER'):
         return host_get_output("podman inspect --type container " + name + " --format \"{{.State.Status}}\"")
     else:
         return host_get_output(f"sudo -u {os.environ.get('SUDO_USER')} podman inspect --type container " + name + " --format \"{{.State.Status}}\"")
@@ -137,7 +137,7 @@ def check_container_status(name):
 
 def core_start_container(name, new_container=False):
     sudo = []
-    if os.environ.get('SUDO_USER') != None:
+    if os.environ.get('SUDO_USER'):
         sudo = ['sudo', '-u', os.environ.get('SUDO_USER')]
     subprocess.call([*sudo, 'podman', 'start', name],
                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -150,7 +150,7 @@ def core_start_container(name, new_container=False):
         subprocess.call(['podman', 'logs', '--since', str(start_time), name])
         exit(1)
 
-    if os.environ.get('SUDO_USER') == None:
+    if not os.environ.get('SUDO_USER'):
         logproc = pexpect.spawn(
             'podman', args=['logs', '-f', '--since', str(start_time), name], timeout=3600)
     else:
@@ -411,7 +411,7 @@ def enter_container():
 
     podman_args = ['--env', 'LC_ALL=C.UTF-8']
     sudo = []
-    if os.environ.get('SUDO_USER') == None:
+    if not os.environ.get('SUDO_USER'):
         podman_args = ['--user', getpass.getuser()]
     else:
         sudo = ['sudo', '-u', os.environ.get(
@@ -420,7 +420,7 @@ def enter_container():
         if name not in ['LANG', 'LC_CTYPE', 'LC_ALL', 'PATH', 'HOST', 'HOSTNAME', 'SHELL'] and not name.startswith('_'):
             podman_args.append('--env')
             podman_args.append(name + '=' + val)
-    if os.environ.get('BLEND_COMMAND') == None or os.environ.get('BLEND_COMMAND') == '':
+    if not os.environ.get('BLEND_COMMAND'):
         if args.pkg == []:
             if os.getcwd() == os.path.expanduser('~') or os.getcwd().startswith(os.path.expanduser('~') + '/'):
                 exit(subprocess.call([*sudo, 'podman', 'exec', *podman_args,

--- a/user
+++ b/user
@@ -162,7 +162,8 @@ def create_container(container_name, distro):
     Create a container
     '''
     if subprocess.run(['podman', 'container', 'exists', container_name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0:
-        error(f'container {colors.bold}{container_name}{colors.reset} already exists')
+        error(
+            f'container {colors.bold}{container_name}{colors.reset} already exists')
         exit(1)
     args = ['blend', 'create-container', '-cn', container_name]
     # blend handles no distro being specified already
@@ -178,7 +179,8 @@ def delete_container(container):
     Delete a container
     '''
     if subprocess.run(['podman', 'container', 'exists', container], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode != 0:
-        error(f'container {colors.bold}{container}{colors.reset} does not exist')
+        error(
+            f'container {colors.bold}{container}{colors.reset} does not exist')
         exit(1)
     subprocess.run(['blend', 'remove-container', container])
 
@@ -190,7 +192,8 @@ def shell(container):
     Enter a shell inside a container
     '''
     if subprocess.run(['podman', 'container', 'exists', container], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode != 0:
-        error(f'container {colors.bold}{container}{colors.reset} does not exist')
+        error(
+            f'container {colors.bold}{container}{colors.reset} does not exist')
         exit(1)
     creation_env = os.environ.copy()
     creation_env['BLEND_NO_CHECK'] = 'true'
@@ -205,12 +208,14 @@ def exec_c(container, cmds):
     Run a command inside a container
     '''
     if subprocess.run(['podman', 'container', 'exists', container], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode != 0:
-        error(f'container {colors.bold}{container}{colors.reset} does not exist')
+        error(
+            f'container {colors.bold}{container}{colors.reset} does not exist')
         exit(1)
     creation_env = os.environ.copy()
     creation_env['BLEND_NO_CHECK'] = 'true'
-    cmds = [ cmd.replace('\\-', '-') for cmd in cmds]
-    subprocess.run(['blend', 'enter', '-cn', container, '--', *cmds], env=creation_env)
+    cmds = [cmd.replace('\\-', '-') for cmd in cmds]
+    subprocess.run(['blend', 'enter', '-cn', container,
+                   '--', *cmds], env=creation_env)
 
 
 @cli.command("install")
@@ -228,7 +233,8 @@ def install_c(container, pkgs):
     elif os.path.isfile(os.path.expanduser(f'~/.local/bin/blend_bin/pacman.{container}')):
         subprocess.run([f'sudo.{container}', 'pacman', '-Syu', *pkgs])
     else:
-        error(f'container {colors.bold}{container}{colors.reset} does not exist')
+        error(
+            f'container {colors.bold}{container}{colors.reset} does not exist')
         exit(1)
 
 
@@ -246,7 +252,8 @@ def remove_c(container, pkgs):
     elif os.path.isfile(os.path.expanduser(f'~/.local/bin/blend_bin/pacman.{container}')):
         subprocess.run([f'sudo.{container}', 'pacman', '-Rcns', *pkgs])
     else:
-        error(f'container {colors.bold}{container}{colors.reset} does not exist')
+        error(
+            f'container {colors.bold}{container}{colors.reset} does not exist')
         exit(1)
 
 

--- a/user
+++ b/user
@@ -208,6 +208,7 @@ def exec_c(container, cmds):
         exit(1)
     creation_env = os.environ.copy()
     creation_env['BLEND_NO_CHECK'] = 'true'
+    cmds = [ cmd.replace('\\-', '-') for cmd in cmds]
     subprocess.run(['blend', 'enter', '-cn', container, '--', *cmds], env=creation_env)
 
 

--- a/user
+++ b/user
@@ -156,18 +156,19 @@ def associate_binary(association):
 
 @cli.command("create-container")
 @click.argument('container_name')
-@click.argument('distro', default='arch')
+@click.argument('distro', required=False)
 def create_container(container_name, distro):
     '''
     Create a container
     '''
-    if distro not in ('arch', 'almalinux-9', 'crystal-linux', 'debian', 'fedora-38', 'kali-linux', 'neurodebian-bookworm', 'rocky-linux', 'ubuntu-22.04', 'ubuntu-23.04'):
-        error(
-            f'distro {colors.bold}{distro}{colors.reset} not supported')
     if subprocess.run(['podman', 'container', 'exists', container_name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0:
         error(f'container {colors.bold}{container_name}{colors.reset} already exists')
         exit(1)
-    subprocess.run(['blend', 'create-container', '-cn', container_name, '-d', distro])
+    args = ['blend', 'create-container', '-cn', container_name]
+    # blend handles no distro being specified already
+    if distro:
+        args.extend(['-d', distro])
+    exit(subprocess.run(args).returncode)
 
 
 @cli.command("delete-container")


### PR DESCRIPTION
Some misc fixes:

- Main thing: Fix distros/images not matching up and being inconsistent; it's a mess all around (4732a57)
  - This adds the old `arch-linux` and `ubuntu-24.04-lts` as aliases so nothing breaks
- Allows passing arguments to commands running in a container (allows escaping hyphens so click doesn't error out)
- Minor code cleanup and format